### PR TITLE
fix(org-policy) adding tag and untag permissions

### DIFF
--- a/backup-organization-policy/main.tf
+++ b/backup-organization-policy/main.tf
@@ -60,6 +60,19 @@ data "aws_iam_policy_document" "organization_backup_policy" {
       values   = ["BACKUP_POLICY"]
     }
   }
+   statement {
+    sid = "AllowBackupPoliciesTagModification"
+    effect = "Allow"
+    principals {
+        identifiers = [var.delegate_account_id]
+        type        = "AWS"
+    }
+    resources = ["*"]
+    actions = [
+      "organizations:TagResource",
+      "organizations:UntagResource"
+    ]
+  }
   statement {
     sid = "AllowBackupPoliciesAttachmentAndDetachmentToAllAccountsAndOUs"
     actions = [

--- a/backup-organization-policy/main.tf
+++ b/backup-organization-policy/main.tf
@@ -60,12 +60,12 @@ data "aws_iam_policy_document" "organization_backup_policy" {
       values   = ["BACKUP_POLICY"]
     }
   }
-   statement {
-    sid = "AllowBackupPoliciesTagModification"
+  statement {
+    sid    = "AllowBackupPoliciesTagModification"
     effect = "Allow"
     principals {
-        identifiers = [var.delegate_account_id]
-        type        = "AWS"
+      identifiers = [var.delegate_account_id]
+      type        = "AWS"
     }
     resources = ["*"]
     actions = [


### PR DESCRIPTION
Create policy permissions to allow delegate account to tag and untag organization policies 